### PR TITLE
add tempo and bpm setters

### DIFF
--- a/adafruit_midi_parser.py
+++ b/adafruit_midi_parser.py
@@ -80,6 +80,12 @@ class MIDIParser:
         """
         return self._tempo
 
+    @tempo.setter
+    def tempo(self, value: int) -> None:
+        if value <= 0:
+            raise ValueError("Tempo must be a positive number of microseconds per quarter note")
+        self._tempo = value
+
     @property
     def ticks_per_beat(self) -> int:
         """
@@ -151,6 +157,12 @@ class MIDIParser:
         :rtype: float
         """
         return 60000000 / self._tempo
+
+    @bpm.setter
+    def bpm(self, value: float) -> None:
+        if value <= 0:
+            raise ValueError("BPM must be a positive number")
+        self._tempo = round(60000000 / value)
 
     @property
     def note_count(self) -> int:


### PR DESCRIPTION
These allow the user to change or override the tempo that the song will play at.

I tested it successfully on Fruit Jam by modifying the tempo of a basic twinkle star midi file.